### PR TITLE
Refactor controller validation helpers

### DIFF
--- a/src/controllers/trip.controller.ts
+++ b/src/controllers/trip.controller.ts
@@ -1,5 +1,13 @@
 import { Request, Response } from 'express';
 import { TripService } from '../services/trip.service';
+import {
+  ensureRequiredFields,
+  parseBoolean,
+  parseNumber,
+  parseString,
+  validateDate,
+  validateTime,
+} from '../utils/validation';
 
 type TripRequestBody = {
   driverId?: unknown;
@@ -32,87 +40,14 @@ const REQUIRED_FIELDS: Array<keyof TripRequestBody> = [
 export class TripController {
   constructor(private readonly tripService = new TripService()) {}
 
-  private parseBoolean(value: unknown): boolean | undefined {
-    if (value === undefined || value === null) {
-      return undefined;
-    }
-
-    if (typeof value === 'boolean') {
-      return value;
-    }
-
-    if (typeof value === 'string') {
-      const normalized = value.toLowerCase().trim();
-      if (['true', '1', 'yes'].includes(normalized)) {
-        return true;
-      }
-      if (['false', '0', 'no'].includes(normalized)) {
-        return false;
-      }
-    }
-
-    throw new Error('El valor debe ser booleano.');
-  }
-
-  private parseNumber(value: unknown, field: string): number {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-
-    if (typeof value === 'string' && value.trim().length > 0) {
-      const parsed = Number(value);
-      if (Number.isFinite(parsed)) {
-        return parsed;
-      }
-    }
-
-    throw new Error(`El campo ${field} debe ser numérico.`);
-  }
-
-  private parseString(value: unknown, field: string): string {
-    if (typeof value === 'string' && value.trim().length > 0) {
-      return value.trim();
-    }
-
-    throw new Error(`El campo ${field} es requerido.`);
-  }
-
-  private validateDate(value: string): string {
-    const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-
-    if (!datePattern.test(value)) {
-      throw new Error('El campo date debe tener el formato YYYY-MM-DD.');
-    }
-
-    return value;
-  }
-
-  private validateTime(value: string): string {
-    const timePattern = /^\d{2}:\d{2}(:\d{2})?$/;
-
-    if (!timePattern.test(value)) {
-      throw new Error('El campo time debe tener el formato HH:mm o HH:mm:ss.');
-    }
-
-    return value;
-  }
-
-  private ensureRequiredFields(body: TripRequestBody): void {
-    const missing = REQUIRED_FIELDS.filter((field) => body[field] === undefined || body[field] === null);
-
-    if (missing.length > 0) {
-      throw new Error(`Faltan los siguientes campos requeridos: ${missing.join(', ')}`);
-    }
-  }
-
   createTrip = async (req: Request, res: Response): Promise<Response> => {
     const body = req.body as TripRequestBody;
 
     try {
-      this.ensureRequiredFields(body);
+      ensureRequiredFields(body, REQUIRED_FIELDS);
 
-      const availableSeats = this.parseNumber(body.availableSeats, 'availableSeats');
-      const pricePerPerson = this.parseNumber(body.pricePerPerson, 'pricePerPerson');
+      const availableSeats = parseNumber(body.availableSeats, 'availableSeats');
+      const pricePerPerson = parseNumber(body.pricePerPerson, 'pricePerPerson');
 
       if (availableSeats <= 0) {
         throw new Error('El campo availableSeats debe ser mayor a 0.');
@@ -122,21 +57,21 @@ export class TripController {
         throw new Error('El campo pricePerPerson no puede ser negativo.');
       }
 
-      const driverId = this.parseString(body.driverId, 'driverId');
+      const driverId = parseString(body.driverId, 'driverId');
       const createdByUserId =
         body.createdByUserId === undefined || body.createdByUserId === null
           ? undefined
-          : this.parseString(body.createdByUserId, 'createdByUserId');
-      const origin = this.parseString(body.origin, 'origin');
-      const destination = this.parseString(body.destination, 'destination');
-      const date = this.validateDate(this.parseString(body.date, 'date'));
-      const time = this.validateTime(this.parseString(body.time, 'time'));
-      const vehicle = this.parseString(body.vehicle, 'vehicle');
+          : parseString(body.createdByUserId, 'createdByUserId');
+      const origin = parseString(body.origin, 'origin');
+      const destination = parseString(body.destination, 'destination');
+      const date = validateDate(parseString(body.date, 'date'));
+      const time = validateTime(parseString(body.time, 'time'));
+      const vehicle = parseString(body.vehicle, 'vehicle');
 
-      const music = this.parseBoolean(body.music);
-      const pets = this.parseBoolean(body.pets);
-      const children = this.parseBoolean(body.children);
-      const luggage = this.parseBoolean(body.luggage);
+      const music = parseBoolean(body.music);
+      const pets = parseBoolean(body.pets);
+      const children = parseBoolean(body.children);
+      const luggage = parseBoolean(body.luggage);
       const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
       const tripInput: Parameters<typeof this.tripService.createTrip>[0] = {
@@ -184,7 +119,7 @@ export class TripController {
     }
   };
 
-    getPublishedTrips = async (_req: Request, res: Response): Promise<Response> => {
+  getPublishedTrips = async (_req: Request, res: Response): Promise<Response> => {
     try {
       const trips = await this.tripService.getPublishedTrips();
 
@@ -201,7 +136,7 @@ export class TripController {
     }
   };
 
-  selectTrip = async(req: Request, res: Response): Promise<Response> => {
+  selectTrip = async (req: Request, res: Response): Promise<Response> => {
     const { tripId } = req.params;
     const { userId, seats = 1 } = req.body;
 
@@ -213,7 +148,7 @@ export class TripController {
         throw new Error('El campo userId es requerido.');
       }
 
-      const seatsNumber = this.parseNumber(seats, 'seats');
+      const seatsNumber = parseNumber(seats, 'seats');
       if (seatsNumber <= 0) {
         throw new Error('El número de asientos debe ser mayor a 0.');
       }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,103 @@
+export const parseBoolean = (value: unknown): boolean | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase().trim();
+    if (['true', '1', 'yes'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  throw new Error('El valor debe ser booleano.');
+};
+
+export const parseNumber = (value: unknown, field: string): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  throw new Error(`El campo ${field} debe ser numérico.`);
+};
+
+export const parseString = (value: unknown, field: string): string => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new Error(`El campo ${field} es requerido.`);
+};
+
+export const ensureRequiredFields = <T extends Record<string, unknown>>(
+  body: T,
+  requiredFields: Array<keyof T>,
+): void => {
+  const missing = requiredFields.filter((field) => body[field] === undefined || body[field] === null);
+
+  if (missing.length > 0) {
+    throw new Error(`Faltan los siguientes campos requeridos: ${missing.join(', ')}`);
+  }
+};
+
+export const validateDate = (value: string): string => {
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+  if (!datePattern.test(value)) {
+    throw new Error('El campo date debe tener el formato YYYY-MM-DD.');
+  }
+
+  return value;
+};
+
+export const validateTime = (value: string): string => {
+  const timePattern = /^\d{2}:\d{2}(:\d{2})?$/;
+
+  if (!timePattern.test(value)) {
+    throw new Error('El campo time debe tener el formato HH:mm o HH:mm:ss.');
+  }
+
+  return value;
+};
+
+export const validateEmail = (email: string): string => {
+  const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!EMAIL_REGEX.test(email)) {
+    throw new Error('El formato del email es inválido.');
+  }
+
+  return email.toLowerCase();
+};
+
+export const validatePhone = (phone: string): string => {
+  const PHONE_REGEX = /^[+\d][\d\s-]{6,}$/;
+
+  if (!PHONE_REGEX.test(phone)) {
+    throw new Error('El formato del teléfono es inválido.');
+  }
+
+  return phone;
+};
+
+export const validatePassword = (password: string): string => {
+  if (password.length < 8) {
+    throw new Error('La contraseña debe tener al menos 8 caracteres.');
+  }
+
+  return password;
+};


### PR DESCRIPTION
## Summary
- extract shared parsing and validation logic into reusable helpers in `src/utils/validation.ts`
- update trip and user controllers to consume the shared parsing and validation utilities

## Testing
- npm run build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c04aa7f8832e9489d06c7106a7ce