### PR TITLE
feat: add login endpoint

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -36,6 +36,33 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   ```
 - **Errores comunes** (`400 Bad Request`): Campos faltantes o formatos inválidos en la solicitud.
 
+### Iniciar sesión
+- **Método**: `POST`
+- **Ruta**: `http://localhost:3000/api/users/login`
+- **Tipo de cuerpo**: `application/json`
+- **Cuerpo requerido**:
+
+  | Campo      | Tipo     | Obligatorio | Descripción |
+  |------------|----------|-------------|-------------|
+  | `email`    | `string` | Sí          | Correo electrónico registrado del usuario. |
+  | `password` | `string` | Sí          | Contraseña del usuario. |
+
+- **Respuesta exitosa** (`200 OK`):
+  ```json
+  {
+    "user": {
+      "id": "string",
+      "name": "string",
+      "email": "string",
+      "phone": "string",
+      "dni": "string",
+      "createdAt": "datetime",
+      "updatedAt": "datetime"
+    }
+  }
+  ```
+- **Errores comunes** (`401 Unauthorized`): Credenciales inválidas.
+
 ## 🚗 Viajes (`/api/trips`)
 
 ### Crear un viaje

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -5,5 +5,6 @@ const userRouter = Router();
 const controller = new UserController();
 
 userRouter.post('/', controller.createUser);
+userRouter.post('/login', controller.loginUser);
 
 export default userRouter;


### PR DESCRIPTION
## Summary
- add a login handler to the user controller and route
- implement password verification and login logic in the user service
- document the new login endpoint in the endpoints guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2d2a86d60832eac43a15df50f6265