### PR TITLE
Add rating support for users

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -23,14 +23,16 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
 - **Respuesta exitosa** (`201 Created`):
   ```json
   {
-    "message": "Usuario creado correctamente.",
-    "data": {
+    "user": {
       "id": "string",
       "name": "string",
       "email": "string",
       "phone": "string",
-      "password": "string",
-      "dni": "string"
+      "dni": "string",
+      "calificacionPromedio": 0,
+      "ratingsCount": 0,
+      "createdAt": "datetime",
+      "updatedAt": "datetime"
     }
   }
   ```
@@ -56,12 +58,55 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
       "email": "string",
       "phone": "string",
       "dni": "string",
+      "calificacionPromedio": 4.5,
+      "ratingsCount": 3,
       "createdAt": "datetime",
       "updatedAt": "datetime"
     }
   }
   ```
 - **Errores comunes** (`401 Unauthorized`): Credenciales inválidas.
+
+### Calificar a un usuario
+- **Método**: `POST`
+- **Ruta**: `http://localhost:3000/api/users/:id/ratings`
+- **Tipo de cuerpo**: `application/json`
+- **Cuerpo requerido**:
+
+  | Campo      | Tipo     | Obligatorio | Descripción |
+  |------------|----------|-------------|-------------|
+  | `score`    | `number` | Sí          | Puntaje entre 1 y 5 (se admite decimal). |
+  | `comment`  | `string` | No          | Comentario opcional de la calificación. |
+  | `authorId` | `string` | No          | Identificador del usuario que emite la calificación. |
+
+- **Respuesta exitosa** (`201 Created`):
+  ```json
+  {
+    "rating": {
+      "id": "string",
+      "score": 5,
+      "comment": "Excelente experiencia",
+      "createdAt": "datetime",
+      "ratedUserId": "string",
+      "authorId": "string"
+    },
+    "user": {
+      "id": "string",
+      "name": "string",
+      "email": "string",
+      "phone": "string",
+      "dni": "string",
+      "calificacionPromedio": 4.8,
+      "ratingsCount": 5,
+      "createdAt": "datetime",
+      "updatedAt": "datetime"
+    }
+  }
+  ```
+
+- **Errores comunes**:
+  - `400 Bad Request`: Falta el puntaje o el formato es incorrecto.
+  - `404 Not Found`: El usuario calificado o el autor no existen.
 
 ## 🚗 Viajes (`/api/trips`)
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { UserService, UserServiceError } from '../services/ser.service';
 import {
   ensureRequiredFields,
+  parseNumber,
   parseString,
   validateEmail,
   validatePassword,
@@ -24,6 +25,14 @@ type LoginRequestBody = {
 };
 
 const LOGIN_REQUIRED_FIELDS: Array<keyof LoginRequestBody> = ['email', 'password'];
+
+type RateUserRequestBody = {
+  score?: unknown;
+  comment?: unknown;
+  authorId?: unknown;
+};
+
+const RATE_REQUIRED_FIELDS: Array<keyof RateUserRequestBody> = ['score'];
 
 export class UserController {
   constructor(private readonly userService = new UserService()) {}
@@ -50,7 +59,13 @@ export class UserController {
 
       const { password: _password, ...userWithoutPassword } = user;
 
-      return res.status(201).json({ user: userWithoutPassword });
+      return res.status(201).json({
+        user: {
+          ...userWithoutPassword,
+          calificacionPromedio: user.calificacionPromedio,
+          ratingsCount: 0,
+        },
+      });
     } catch (error: unknown) {
       if (error instanceof UserServiceError) {
         return res.status(error.statusCode).json({ message: error.message });
@@ -74,9 +89,81 @@ export class UserController {
       const password = parseString(body.password, 'password');
 
       const user = await this.userService.login(email, password);
+      const ratingsCount = await this.userService.getRatingsCount(user.id);
       const { password: _password, ...userWithoutPassword } = user;
 
-      return res.status(200).json({ user: userWithoutPassword });
+      return res.status(200).json({
+        user: {
+          ...userWithoutPassword,
+          calificacionPromedio: user.calificacionPromedio,
+          ratingsCount,
+        },
+      });
+    } catch (error: unknown) {
+      if (error instanceof UserServiceError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+
+      if (error instanceof Error) {
+        return res.status(400).json({ message: error.message });
+      }
+
+      return res.status(500).json({ message: 'Ocurrió un error inesperado.' });
+    }
+  };
+
+  rateUser = async (req: Request, res: Response): Promise<Response> => {
+    const body = req.body as RateUserRequestBody;
+    const { id: ratedUserId } = req.params;
+
+    if (!ratedUserId) {
+      return res.status(400).json({ message: 'El usuario a calificar es requerido.' });
+    }
+
+    try {
+      ensureRequiredFields(body, RATE_REQUIRED_FIELDS);
+
+      const score = parseNumber(body.score, 'score');
+      const comment = typeof body.comment === 'string' && body.comment.trim().length > 0 ? body.comment.trim() : undefined;
+      const authorId = body.authorId !== undefined && body.authorId !== null ? parseString(body.authorId, 'authorId') : undefined;
+
+      const ratingInput: {
+        ratedUserId: string;
+        score: number;
+        comment?: string;
+        authorId?: string;
+      } = {
+        ratedUserId,
+        score,
+      };
+
+      if (comment !== undefined) {
+        ratingInput.comment = comment;
+      }
+
+      if (authorId !== undefined) {
+        ratingInput.authorId = authorId;
+      }
+
+      const { rating, ratedUser, ratingsCount } = await this.userService.addRating(ratingInput);
+
+      const { password: _password, ...userWithoutPassword } = ratedUser;
+
+      return res.status(201).json({
+        rating: {
+          id: rating.id,
+          score: rating.score,
+          comment: rating.comment,
+          createdAt: rating.createdAt,
+          ratedUserId,
+          authorId: rating.author?.id ?? authorId ?? null,
+        },
+        user: {
+          ...userWithoutPassword,
+          calificacionPromedio: ratedUser.calificacionPromedio,
+          ratingsCount,
+        },
+      });
     } catch (error: unknown) {
       if (error instanceof UserServiceError) {
         return res.status(error.statusCode).json({ message: error.message });

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -2,8 +2,9 @@ import 'dotenv/config';
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 import { Trip } from '../models/trip.entity';
-import { TripSelection } from "../models/trip-selection.entity";
+import { TripSelection } from '../models/trip-selection.entity';
 import { User } from '../models/user.entity';
+import { Rating } from '../models/rating.entity';
 
 const {
   DB_HOST = 'localhost',
@@ -26,7 +27,7 @@ export const AppDataSource = new DataSource({
   database: DB_NAME,
   synchronize: DB_SYNCHRONIZE === 'true',
   logging: DB_LOGGING === 'true',
-  entities: [Trip, TripSelection, User],
+  entities: [Trip, TripSelection, User, Rating],
 });
 
 export const initializeDataSource = async (): Promise<DataSource> => {

--- a/src/models/rating.entity.ts
+++ b/src/models/rating.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity({ name: 'ratings' })
+export class Rating {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({
+    type: 'decimal',
+    precision: 3,
+    scale: 2,
+    transformer: {
+      to: (value: number): number => value,
+      from: (value: string | null): number => (value ? Number(value) : 0),
+    },
+  })
+  score!: number;
+
+  @Column({ type: 'text', nullable: true })
+  comment?: string | null;
+
+  @ManyToOne(() => User, (user) => user.receivedRatings, { nullable: false, onDelete: 'CASCADE' })
+  ratedUser!: User;
+
+  @ManyToOne(() => User, (user) => user.givenRatings, { nullable: true, onDelete: 'SET NULL' })
+  author?: User | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/src/models/user.entity.ts
+++ b/src/models/user.entity.ts
@@ -1,34 +1,54 @@
 import {
-    Column,
-    CreateDateColumn,
-    Entity,
-    PrimaryGeneratedColumn,
-    UpdateDateColumn,
-  } from 'typeorm';
-  
-  @Entity({ name: 'users' })
-  export class User {
-    @PrimaryGeneratedColumn('uuid')
-    id!: string;
-  
-    @Column({ type: 'varchar', length: 255 })
-    name!: string;
-  
-    @Column({ type: 'varchar', length: 255, unique: true })
-    email!: string;
-  
-    @Column({ type: 'varchar', length: 30 })
-    phone!: string;
-  
-    @Column({ type: 'varchar', length: 255 })
-    password!: string;
-  
-    @Column({ type: 'varchar', length: 20, unique: true })
-    dni!: string;
-  
-    @CreateDateColumn({ type: 'timestamptz' })
-    createdAt!: Date;
-  
-    @UpdateDateColumn({ type: 'timestamptz' })
-    updatedAt!: Date;
-  }
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Rating } from './rating.entity';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  email!: string;
+
+  @Column({ type: 'varchar', length: 30 })
+  phone!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  password!: string;
+
+  @Column({ type: 'varchar', length: 20, unique: true })
+  dni!: string;
+
+  @Column({
+    type: 'decimal',
+    precision: 3,
+    scale: 2,
+    default: 0,
+    transformer: {
+      to: (value?: number): number => (value ?? 0),
+      from: (value: string | null): number => (value ? Number(value) : 0),
+    },
+  })
+  calificacionPromedio!: number;
+
+  @OneToMany(() => Rating, (rating) => rating.ratedUser)
+  receivedRatings?: Rating[];
+
+  @OneToMany(() => Rating, (rating) => rating.author)
+  givenRatings?: Rating[];
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -6,5 +6,6 @@ const controller = new UserController();
 
 userRouter.post('/', controller.createUser);
 userRouter.post('/login', controller.loginUser);
+userRouter.post('/:id/ratings', controller.rateUser);
 
 export default userRouter;

--- a/src/services/ser.service.ts
+++ b/src/services/ser.service.ts
@@ -2,6 +2,7 @@ import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from 'crypto';
 import { promisify } from 'util';
 import { DataSource, Repository } from 'typeorm';
 import { AppDataSource } from '../database/data-source';
+import { Rating } from '../models/rating.entity';
 import { User } from '../models/user.entity';
 
 const scrypt = promisify(scryptCallback);
@@ -25,11 +26,19 @@ export class UserService {
   constructor(private readonly dataSource: DataSource = AppDataSource) {}
 
   private get repository(): Repository<User> {
+    this.ensureDataSourceInitialized();
+    return this.dataSource.getRepository(User);
+  }
+
+  private get ratingRepository(): Repository<Rating> {
+    this.ensureDataSourceInitialized();
+    return this.dataSource.getRepository(Rating);
+  }
+
+  private ensureDataSourceInitialized(): void {
     if (!this.dataSource.isInitialized) {
       throw new Error('Data source has not been initialized.');
     }
-
-    return this.dataSource.getRepository(User);
   }
 
   private async hashPassword(password: string): Promise<string> {
@@ -80,6 +89,7 @@ export class UserService {
       phone: input.phone.trim(),
       dni: normalizedDni,
       password: passwordHash,
+      calificacionPromedio: 0,
     });
 
     return repository.save(user);
@@ -102,5 +112,75 @@ export class UserService {
     }
 
     return user;
+  }
+
+  async getRatingsCount(userId: string): Promise<number> {
+    const repository = this.ratingRepository;
+    return repository.count({ where: { ratedUser: { id: userId } } });
+  }
+
+  async addRating(input: {
+    ratedUserId: string;
+    score: number;
+    comment?: string;
+    authorId?: string;
+  }): Promise<{ rating: Rating; ratedUser: User; ratingsCount: number }> {
+    this.ensureDataSourceInitialized();
+
+    const normalizedScore = Math.round(input.score * 100) / 100;
+
+    if (normalizedScore < 1 || normalizedScore > 5) {
+      throw new UserServiceError('La calificación debe estar entre 1 y 5.', 400);
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      const userRepository = manager.getRepository(User);
+      const ratingRepository = manager.getRepository(Rating);
+
+      const ratedUser = await userRepository.findOne({ where: { id: input.ratedUserId } });
+
+      if (!ratedUser) {
+        throw new UserServiceError('El usuario a calificar no existe.', 404);
+      }
+
+      let author: User | null = null;
+
+      if (input.authorId) {
+        author = await userRepository.findOne({ where: { id: input.authorId } });
+
+        if (!author) {
+          throw new UserServiceError('El autor de la calificación no existe.', 404);
+        }
+      }
+
+      const trimmedComment = input.comment?.trim();
+
+      const rating = ratingRepository.create({
+        score: normalizedScore,
+        comment: trimmedComment && trimmedComment.length > 0 ? trimmedComment : null,
+        ratedUser,
+        author: author ?? null,
+      });
+
+      const savedRating = await ratingRepository.save(rating);
+
+      const stats = await ratingRepository
+        .createQueryBuilder('rating')
+        .select('AVG(rating.score)', 'avg')
+        .addSelect('COUNT(rating.id)', 'count')
+        .where('rating.ratedUserId = :userId', { userId: ratedUser.id })
+        .getRawOne<{ avg: string | null; count: string }>();
+
+      const average = stats?.avg ? Math.round(Number(stats.avg) * 100) / 100 : 0;
+      ratedUser.calificacionPromedio = average;
+
+      await userRepository.save(ratedUser);
+
+      return {
+        rating: savedRating,
+        ratedUser,
+        ratingsCount: stats?.count ? Number(stats.count) : 0,
+      };
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add a Rating entity related to users and persist the cached average score
- expose an endpoint to create ratings while returning updated user statistics
- document the new rating workflow and surface rating data in user responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68faa6de1838832ebd8c2fb7170980eb