### PR TITLE
Add endpoint to fetch user details by id

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -67,6 +67,35 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   ```
 - **Errores comunes** (`401 Unauthorized`): Credenciales inválidas.
 
+### Obtener un usuario por ID
+- **Método**: `GET`
+- **Ruta**: `http://localhost:3000/api/users/:id`
+- **Parámetros de ruta**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción |
+  |-----------|----------|-------------|-------------|
+  | `id`      | `string` | Sí          | Identificador único del usuario (UUID). |
+
+- **Respuesta exitosa** (`200 OK`):
+  ```json
+  {
+    "user": {
+      "id": "string",
+      "name": "string",
+      "email": "string",
+      "phone": "string",
+      "dni": "string",
+      "calificacionPromedio": 4.5,
+      "ratingsCount": 3,
+      "createdAt": "datetime",
+      "updatedAt": "datetime"
+    }
+  }
+  ```
+- **Errores comunes**:
+  - `400 Bad Request`: El parámetro `id` está ausente o es inválido.
+  - `404 Not Found`: No existe un usuario con el identificador indicado.
+
 ### Calificar a un usuario
 - **Método**: `POST`
 - **Ruta**: `http://localhost:3000/api/users/:id/ratings`

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -176,4 +176,31 @@ export class UserController {
       return res.status(500).json({ message: 'Ocurrió un error inesperado.' });
     }
   };
+
+  getUserById = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const userId = parseString(req.params.id, 'id');
+
+      const { user, ratingsCount } = await this.userService.getUserById(userId);
+      const { password: _password, ...userWithoutPassword } = user;
+
+      return res.status(200).json({
+        user: {
+          ...userWithoutPassword,
+          calificacionPromedio: user.calificacionPromedio,
+          ratingsCount,
+        },
+      });
+    } catch (error: unknown) {
+      if (error instanceof UserServiceError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+
+      if (error instanceof Error) {
+        return res.status(400).json({ message: error.message });
+      }
+
+      return res.status(500).json({ message: 'Ocurrió un error inesperado.' });
+    }
+  };
 }

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -6,6 +6,7 @@ const controller = new UserController();
 
 userRouter.post('/', controller.createUser);
 userRouter.post('/login', controller.loginUser);
+userRouter.get('/:id', controller.getUserById);
 userRouter.post('/:id/ratings', controller.rateUser);
 
 export default userRouter;

--- a/src/services/ser.service.ts
+++ b/src/services/ser.service.ts
@@ -114,6 +114,21 @@ export class UserService {
     return user;
   }
 
+  async getUserById(id: string): Promise<{ user: User; ratingsCount: number }> {
+    const repository = this.repository;
+    const trimmedId = id.trim();
+
+    const user = await repository.findOne({ where: { id: trimmedId } });
+
+    if (!user) {
+      throw new UserServiceError('El usuario no existe.', 404);
+    }
+
+    const ratingsCount = await this.getRatingsCount(user.id);
+
+    return { user, ratingsCount };
+  }
+
   async getRatingsCount(userId: string): Promise<number> {
     const repository = this.ratingRepository;
     return repository.count({ where: { ratedUser: { id: userId } } });


### PR DESCRIPTION
## Summary
- add a service method to retrieve a user and ratings count by identifier
- expose a GET /api/users/:id route that returns user information without the password
- document the new endpoint in ENDPOINTS.md

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6909154d3c00832e896f36593feeb008