### PR TITLE
feat: add endpoint to update user password

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -68,6 +68,43 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   ```
 - **Errores comunes** (`401 Unauthorized`): Credenciales inválidas.
 
+### Crear una nueva contraseña
+- **Método**: `POST`
+- **Ruta**: `http://localhost:3000/api/users/:id/password`
+- **Parámetros de ruta**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción |
+  |-----------|----------|-------------|-------------|
+  | `id`      | `string` | Sí          | Identificador del usuario al que se le actualizará la contraseña. |
+
+- **Tipo de cuerpo**: `application/json`
+- **Cuerpo requerido**:
+
+  | Campo      | Tipo     | Obligatorio | Descripción |
+  |------------|----------|-------------|-------------|
+  | `password` | `string` | Sí          | Nueva contraseña del usuario (mínimo 8 caracteres). |
+
+- **Respuesta exitosa** (`200 OK`):
+  ```json
+  {
+    "message": "Contraseña actualizada correctamente.",
+    "user": {
+      "id": "string",
+      "name": "string",
+      "email": "string",
+      "phone": "string",
+      "dni": "string",
+      "calificacionPromedio": 4.5,
+      "ratingsCount": 3,
+      "createdAt": "datetime",
+      "updatedAt": "datetime"
+    }
+  }
+  ```
+- **Errores comunes**:
+  - `400 Bad Request`: Falta el campo `password` o no cumple con las validaciones.
+  - `404 Not Found`: El usuario indicado no existe.
+
 ### Obtener un usuario por ID
 - **Método**: `GET`
 - **Ruta**: `http://localhost:3000/api/users/:id`

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -7,6 +7,7 @@ const controller = new UserController();
 userRouter.post('/', controller.createUser);
 userRouter.post('/login', controller.loginUser);
 userRouter.get('/:id', controller.getUserById);
+userRouter.post('/:id/password', controller.updatePassword);
 userRouter.post('/:id/ratings', controller.rateUser);
 
 export default userRouter;

--- a/src/services/ser.service.ts
+++ b/src/services/ser.service.ts
@@ -198,4 +198,20 @@ export class UserService {
       };
     });
   }
+
+  async updatePassword(userId: string, newPassword: string): Promise<User> {
+    const repository = this.repository;
+    const trimmedId = userId.trim();
+
+    const user = await repository.findOne({ where: { id: trimmedId } });
+
+    if (!user) {
+      throw new UserServiceError('El usuario no existe.', 404);
+    }
+
+    const passwordHash = await this.hashPassword(newPassword);
+    user.password = passwordHash;
+
+    return repository.save(user);
+  }
 }


### PR DESCRIPTION
## Summary
- add controller logic to validate and update user passwords
- expose the POST /api/users/:id/password route and supporting service method
- document the new password endpoint in ENDPOINTS.md

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6909255ec4a0832e85627e2fc1957977