### PR TITLE
feat: add endpoint to cancel trips

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -353,6 +353,29 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
 }
 ```
 
+### Cancelar un viaje
+
+- **Método**: `DELETE`
+- **Ruta**: `http://localhost:3000/api/trips/:id`
+- **Parámetros**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción                               |
+  |-----------|----------|-------------|-------------------------------------------|
+  | `id`      | `string` | Sí          | Identificador único del viaje a cancelar. |
+
+- **Respuesta exitosa** (`200 OK`):
+
+```json
+{
+  "message": "Viaje cancelado correctamente."
+}
+```
+
+- **Errores comunes**:
+  - `400 Bad Request`: Falta el parámetro `id`.
+  - `404 Not Found`: El viaje indicado no existe.
+  - `500 Internal Server Error`: Error inesperado al cancelar el viaje.
+
 ## 🚗 Viajes de un usuario (/api/trips/users/:userId)
 - Obtener todos los viajes de un usuario
 - **Método**: GET

--- a/src/controllers/trip.controller.ts
+++ b/src/controllers/trip.controller.ts
@@ -179,13 +179,35 @@ export class TripController {
 
       const trip = await this.tripService.getTripById(tripId);
 
-      if (!tripId) {
+      if (!trip) {
         return res.status(404).json({ message: 'Viaje no encontrado' });
       }
 
       return res.status(200).json(trip);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error inesperado al obtener el viaje.';
+      return res.status(500).json({ message });
+    }
+  };
+
+  cancelTrip = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { tripId } = req.params;
+
+      if (!tripId) {
+        return res.status(400).json({ message: 'Falta el parámetro tripId' });
+      }
+
+      await this.tripService.cancelTrip(tripId);
+
+      return res.status(200).json({ message: 'Viaje cancelado correctamente.' });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'El viaje no existe.') {
+        return res.status(404).json({ message: error.message });
+      }
+
+      const message = error instanceof Error ? error.message : 'Error inesperado al cancelar el viaje.';
+
       return res.status(500).json({ message });
     }
   };

--- a/src/routes/trip.routes.ts
+++ b/src/routes/trip.routes.ts
@@ -8,6 +8,7 @@ router.get('/reservations', tripController.getAllReservations);
 router.post('/', tripController.createTrip);
 router.get('/', tripController.getPublishedTrips);
 
+router.delete('/:tripId', tripController.cancelTrip);
 router.get('/:tripId', tripController.getTripById);
 router.post('/:tripId/select', tripController.selectTrip);
 router.get('/users/:userId/last', tripController.getLastTripByUser);

--- a/src/services/trip.service.ts
+++ b/src/services/trip.service.ts
@@ -90,6 +90,16 @@ export class TripService {
     return await this.repository.findOneBy({ id: tripId });
   }
 
+  async cancelTrip(tripId: string): Promise<void> {
+    const repository = this.repository;
+
+    const result = await repository.delete(tripId);
+
+    if (result.affected === 0) {
+      throw new Error('El viaje no existe.');
+    }
+  }
+
   async getLastTripByUser(userId: string): Promise<Trip | null> {
     const repository = this.repository;
 


### PR DESCRIPTION
## Summary
- add a trip service helper to delete existing trips and surface errors when the record is missing
- expose a new controller action and route to cancel a trip through DELETE /api/trips/:tripId
- document the cancel trip endpoint in ENDPOINTS.md

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691145bdf1d0832e8730f1838d576b3a)