### PR TITLE
Add trip state management endpoints

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -224,7 +224,7 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   ```json
   {
     "message": "Viaje creado correctamente.",
-    "data": { /* Objeto del viaje creado */ }
+    "data": { /* Objeto del viaje creado, incluyendo el estado inicial "pending" */ }
   }
   ```
 - **Errores comunes** (`400 Bad Request`): Campos faltantes o formatos inválidos en la solicitud.
@@ -271,6 +271,7 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
       "pets": "boolean",
       "children": "boolean",
       "luggage": "boolean",
+      "state": "string",
       "notes": "string | null",
       "createdAt": "datetime",
       "updatedAt": "datetime"
@@ -306,6 +307,7 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   "pets": false,
   "children": true,
   "luggage": true,
+  "state": "pending",
   "notes": "Salida puntual, se permite un bolso pequeño por persona.",
   "createdAt": "2025-10-08T01:26:59.174Z",
   "updatedAt": "2025-10-08T01:41:01.636Z"
@@ -341,11 +343,12 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
     "time": "08:30:00",
     "availableSeats": 5,
     "pricePerPerson": "12000.00",
-    "vehicle": "Toyota Corolla 2020",
-    "music": true,
-    "pets": false,
-    "children": true,
+  "vehicle": "Toyota Corolla 2020",
+  "music": true,
+  "pets": false,
+  "children": true,
     "luggage": true,
+    "state": "pending",
     "notes": "Salida puntual, se permite un bolso pequeño por persona.",
     "createdAt": "2025-10-08T01:26:59.174Z",
     "updatedAt": "2025-10-08T02:28:43.205Z"
@@ -375,6 +378,62 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   - `400 Bad Request`: Falta el parámetro `id`.
   - `404 Not Found`: El viaje indicado no existe.
   - `500 Internal Server Error`: Error inesperado al cancelar el viaje.
+
+### Marcar un viaje como "en curso"
+
+- **Método**: `PATCH`
+- **Ruta**: `http://localhost:3000/api/trips/:id/start`
+- **Parámetros**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción                                        |
+  |-----------|----------|-------------|----------------------------------------------------|
+  | `id`      | `string` | Sí          | Identificador único del viaje a actualizar.        |
+
+- **Respuesta exitosa** (`200 OK`):
+
+```json
+{
+  "message": "Viaje marcado como en curso correctamente.",
+  "data": {
+    "id": "string",
+    "state": "in_progress",
+    /* resto de los campos del viaje */
+  }
+}
+```
+
+- **Errores comunes**:
+  - `400 Bad Request`: La transición de estado no es válida para el viaje.
+  - `404 Not Found`: El viaje indicado no existe.
+  - `500 Internal Server Error`: Error inesperado al actualizar el estado del viaje.
+
+### Marcar un viaje como "finalizado"
+
+- **Método**: `PATCH`
+- **Ruta**: `http://localhost:3000/api/trips/:id/complete`
+- **Parámetros**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción                                        |
+  |-----------|----------|-------------|----------------------------------------------------|
+  | `id`      | `string` | Sí          | Identificador único del viaje a actualizar.        |
+
+- **Respuesta exitosa** (`200 OK`):
+
+```json
+{
+  "message": "Viaje marcado como finalizado correctamente.",
+  "data": {
+    "id": "string",
+    "state": "completed",
+    /* resto de los campos del viaje */
+  }
+}
+```
+
+- **Errores comunes**:
+  - `400 Bad Request`: La transición de estado no es válida para el viaje.
+  - `404 Not Found`: El viaje indicado no existe.
+  - `500 Internal Server Error`: Error inesperado al actualizar el estado del viaje.
 
 ## 🚗 Viajes de un usuario (/api/trips/users/:userId)
 - Obtener todos los viajes de un usuario
@@ -407,6 +466,7 @@ Este endpoint devuelve todos los viajes asociados a un usuario, tanto los que re
       "pets": "boolean",
       "children": "boolean",
       "luggage": "boolean",
+      "state": "string",
       "notes": "string | null",
       "createdAt": "datetime",
       "updatedAt": "datetime"

--- a/src/controllers/trip.controller.ts
+++ b/src/controllers/trip.controller.ts
@@ -212,6 +212,64 @@ export class TripController {
     }
   };
 
+  startTrip = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { tripId } = req.params;
+
+      if (!tripId) {
+        return res.status(400).json({ message: 'Falta el parámetro tripId' });
+      }
+
+      const trip = await this.tripService.updateTripState(tripId, 'in_progress');
+
+      return res.status(200).json({
+        message: 'Viaje marcado como en curso correctamente.',
+        data: trip,
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'El viaje no existe.') {
+          return res.status(404).json({ message: error.message });
+        }
+
+        if (error.message === 'Transición de estado no válida para el viaje.') {
+          return res.status(400).json({ message: error.message });
+        }
+      }
+
+      return res.status(500).json({ message: 'Error inesperado al actualizar el estado del viaje.' });
+    }
+  };
+
+  completeTrip = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { tripId } = req.params;
+
+      if (!tripId) {
+        return res.status(400).json({ message: 'Falta el parámetro tripId' });
+      }
+
+      const trip = await this.tripService.updateTripState(tripId, 'completed');
+
+      return res.status(200).json({
+        message: 'Viaje marcado como finalizado correctamente.',
+        data: trip,
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'El viaje no existe.') {
+          return res.status(404).json({ message: error.message });
+        }
+
+        if (error.message === 'Transición de estado no válida para el viaje.') {
+          return res.status(400).json({ message: error.message });
+        }
+      }
+
+      return res.status(500).json({ message: 'Error inesperado al actualizar el estado del viaje.' });
+    }
+  };
+
   getLastTripByUser = async (req: Request, res: Response): Promise<Response> => {
     try {
       const { userId } = req.params;

--- a/src/models/trip.entity.ts
+++ b/src/models/trip.entity.ts
@@ -6,6 +6,8 @@ import {
     Entity,
   } from 'typeorm';
   
+  export type TripState = 'pending' | 'in_progress' | 'completed';
+
   @Entity({ name: 'trips' })
   export class Trip {
     @PrimaryGeneratedColumn('uuid')
@@ -52,6 +54,9 @@ import {
   
     @Column({ type: 'text', nullable: true })
     notes?: string | null;
+
+    @Column({ type: 'varchar', length: 50, default: 'pending' })
+    state!: TripState;
   
     @CreateDateColumn({ type: 'timestamptz' })
     createdAt!: Date;

--- a/src/routes/trip.routes.ts
+++ b/src/routes/trip.routes.ts
@@ -9,6 +9,8 @@ router.post('/', tripController.createTrip);
 router.get('/', tripController.getPublishedTrips);
 
 router.delete('/:tripId', tripController.cancelTrip);
+router.patch('/:tripId/start', tripController.startTrip);
+router.patch('/:tripId/complete', tripController.completeTrip);
 router.get('/:tripId', tripController.getTripById);
 router.post('/:tripId/select', tripController.selectTrip);
 router.get('/users/:userId/last', tripController.getLastTripByUser);


### PR DESCRIPTION
## Summary
- add a state column to trips and enforce valid transitions
- expose PATCH endpoints to mark trips as in progress or completed
- document the new endpoints and state field in ENDPOINTS.md

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128cbbe9f0832e961110889a120ecc)