### PR TITLE
Add endpoint to list trip passengers

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -435,6 +435,41 @@ Esta guía describe los endpoints disponibles en el servidor Express. Todas las 
   - `404 Not Found`: El viaje indicado no existe.
   - `500 Internal Server Error`: Error inesperado al actualizar el estado del viaje.
 
+### Obtener los pasajeros de un viaje
+
+- **Método**: `GET`
+- **Ruta**: `http://localhost:3000/api/trips/:tripId/passengers`
+- **Parámetros**:
+
+  | Parámetro | Tipo     | Obligatorio | Descripción                              |
+  |-----------|----------|-------------|------------------------------------------|
+  | `tripId`  | `string` | Sí          | Identificador del viaje a consultar.     |
+
+- **Descripción**: Devuelve la lista de pasajeros que reservaron un viaje, junto con la cantidad de asientos que posee cada reserva.
+
+- **Respuesta exitosa** (`200 OK`):
+
+  ```json
+  {
+    "message": "Pasajeros obtenidos correctamente.",
+    "data": [
+      {
+        "id": "string",
+        "name": "string",
+        "email": "string",
+        "phone": "string",
+        "dni": "string",
+        "seats": 2
+      }
+    ]
+  }
+  ```
+
+- **Errores comunes**:
+  - `400 Bad Request`: Falta el parámetro `tripId`.
+  - `404 Not Found`: El viaje indicado no existe.
+  - `500 Internal Server Error`: Error inesperado al obtener los pasajeros del viaje.
+
 ## 🚗 Viajes de un usuario (/api/trips/users/:userId)
 - Obtener todos los viajes de un usuario
 - **Método**: GET

--- a/src/controllers/trip.controller.ts
+++ b/src/controllers/trip.controller.ts
@@ -190,6 +190,30 @@ export class TripController {
     }
   };
 
+  getPassengersByTrip = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { tripId } = req.params;
+
+      if (!tripId) {
+        return res.status(400).json({ message: 'El parámetro tripId es requerido.' });
+      }
+
+      const passengers = await this.tripService.getPassengersByTrip(tripId);
+
+      return res.status(200).json({
+        message: 'Pasajeros obtenidos correctamente.',
+        data: passengers,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'El viaje no existe.') {
+        return res.status(404).json({ message: error.message });
+      }
+
+      const message = error instanceof Error ? error.message : 'Error inesperado al obtener los pasajeros del viaje.';
+      return res.status(500).json({ message });
+    }
+  };
+
   cancelTrip = async (req: Request, res: Response): Promise<Response> => {
     try {
       const { tripId } = req.params;

--- a/src/routes/trip.routes.ts
+++ b/src/routes/trip.routes.ts
@@ -11,6 +11,7 @@ router.get('/', tripController.getPublishedTrips);
 router.delete('/:tripId', tripController.cancelTrip);
 router.patch('/:tripId/start', tripController.startTrip);
 router.patch('/:tripId/complete', tripController.completeTrip);
+router.get('/:tripId/passengers', tripController.getPassengersByTrip);
 router.get('/:tripId', tripController.getTripById);
 router.post('/:tripId/select', tripController.selectTrip);
 router.get('/users/:userId/last', tripController.getLastTripByUser);


### PR DESCRIPTION
## Summary
- add service logic to gather passengers for a trip along with their reserved seats
- expose a GET /api/trips/:tripId/passengers endpoint that returns the collected information with proper error handling
- document the new endpoint in ENDPOINTS.md

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba4bdb904832ea476f9ef4173d73e)